### PR TITLE
fix bug for install python setup.py on python 3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 import platform
+import sys
 
 from Cython.Build import cythonize
 
@@ -49,5 +50,5 @@ setup(name='kss',
           "License :: OSI Approved :: BSD License",
           "Operating System :: OS Independent",
       ],
-      ext_modules=cythonize(ext, language_level="3")
+      ext_modules=cythonize(ext, language_level=sys.version_info[0])
       )


### PR DESCRIPTION
I fix the bug for installing `python setup.py install` on my mac & python 3.6

```
python setup.py install --record files.txt
..
/lib/python3.6/site-packages/Cython-0.27.3-py3.6-macosx-10.12-x86_64.egg/Cython/Compiler/Main.py", line 98, in set_language_level
    if level >= 3:
TypeError: '>=' not supported between instances of 'str' and 'int'
```

