### PR TITLE
add split_chunks function

### DIFF
--- a/kss.pyx
+++ b/kss.pyx
@@ -2,6 +2,8 @@ from libcpp.string cimport string
 from libcpp.vector cimport vector
 
 from typing import List
+from collections import namedtuple
+import math
 
 cdef extern from "sentence_splitter.h":
     vector[string] splitSentences(string)
@@ -14,3 +16,34 @@ def split_sentences(str) -> List[str]:
         results.append(r.decode('utf-8'))
 
     return results
+
+SentenceIndex = namedtuple('SentenceIndex', ['start', 'end'])
+ChunkWithIndex = namedtuple('ChunkWithIndex', ['start', 'text'])
+
+def split_sentences_index(text) -> List[SentenceIndex]:
+    def get_sentence_index(sentence):
+        return SentenceIndex(text.index(sentence), text.index(sentence) + len(sentence))
+    sentences = split_sentences(text)
+    return [get_sentence_index(sentence) for sentence in sentences]
+
+
+def split_chunks(text: str, max_length=128, overlap=True, indexes=None) -> List[ChunkWithIndex]:
+    def get_chunk_with_index():
+        start = span[0].start
+        end = span[-1].end
+        return ChunkWithIndex(span[0].start, text[start:end])
+    if(indexes is None):
+        indexes = split_sentences_index(text)
+    span = []
+    chunks = []
+    for index in indexes:
+        if(len(span) > 0):
+            if(index.end - span[0].start > max_length):  # len = last_end - first_start
+                chunks.append(get_chunk_with_index())
+                if(overlap):
+                    span = span[math.trunc(len(span)/2):]  # cut half
+                else:
+                    span = []
+        span.append(index)
+    chunks.append(get_chunk_with_index())
+    return chunks

--- a/kss.pyx
+++ b/kss.pyx
@@ -27,7 +27,7 @@ def split_sentences_index(text) -> List[SentenceIndex]:
     return [get_sentence_index(sentence) for sentence in sentences]
 
 
-def split_chunks(text: str, max_length=128, overlap=True, indexes=None) -> List[ChunkWithIndex]:
+def split_chunks(text: str, max_length=128, overlap=False, indexes=None) -> List[ChunkWithIndex]:
     def get_chunk_with_index():
         start = span[0].start
         end = span[-1].end


### PR DESCRIPTION
안녕하세요,

kss 라이브러리 사용중에 문장 단위가 아닌 청크 단위로 작업을 진행할 필요성이 생겨서 split_chunks 함수를 만들었습니다. 개인적으로 만들었지만 혹시 필요한 분들이 있을 것 같아.. 부끄럽지만 pull request 신청 드립니다.

**split_chunks**

sentence를 모아서 max_length 이하의 청크를 만듭니다. overlap이 설정되어 있을 경우 슬라이딩 윈도우와 유사하게 청킹 합니다.

다음은 해당 함수의 실행 예 입니다.

```python
>>> longtext = "NoSQL이라고 하는 말은 No 'English'라고 하는 말과 마찬가지다. 세상에는 영어 말고도 수많은 언어가 존재한다. MongoDB에서 사용하는 쿼리 언어와 CouchDB에서 사용하는 쿼리 언어는 서로 전혀 다르다. 그럼에도 이 두 쿼리 언어는 같은 NoSQL 카테고리에 속한다. 어쨌거나 SQL이 아니기 때문이다. 또한 NoSQL이 No RDBMS를 의미하지는 않는다. BerkleyDB같은 예외가 있기 때문이다. 그리고 No RDBMS가 NoSQL인 것도 아니다. SQL호환 레이어를 제공하는 KV-store라는 예외가 역시 존재한다. 물론 KV-store의 특징상 range query를 where절에 넣을 수 없으므로 완전한 SQL은 못 되고 SQL의 부분집합 정도를 제공한다."
>>> kss.split_chunks(longtext, max_length=128, overlap=False)

[ChunkWithIndex(start=0, text="NoSQL이라고 하는 말은 No 'English'라고 하는 말과 마찬가지다. 세상에는 영어 말고도 수많은 언어가 존재한다. MongoDB에서 사용하는 쿼리 언어와 CouchDB에서 사용하는 쿼리 언어는 서로 전혀 다르다."), 
ChunkWithIndex(start=124, text='그럼에도 이 두 쿼리 언어는 같은 NoSQL 카테고리에 속한다. 어쨌거나 SQL이 아니기 때문이다. 또한 NoSQL이 No RDBMS를 의미하지는 않는다. BerkleyDB같은 예외가 있기 때문이다.'), 
ChunkWithIndex(start=236, text='그리고 No RDBMS가 NoSQL인 것도 아니다. SQL호환 레이어를 제공하는 KV-store라는 예외가 역시 존재한다.'), 
ChunkWithIndex(start=305, text='물론 KV-store의 특징상 range query를 where절에 넣을 수 없으므로 완전한 SQL은 못 되고 SQL의 부분집합 정도를 제공한다.')]
```

제가 pull request가 처음이라, 혹시 부족하거나 잘 못 한 부분 있다면 조언 바라겠습니다.

감사합니다.